### PR TITLE
Updated `league/openapi-psr7-validator` version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "league/openapi-psr7-validator": "^0.14|^0.15",
+        "league/openapi-psr7-validator": "^0.14|^0.15|^0.16",
         "nyholm/psr7": "^1.3",
         "symfony/psr-http-message-bridge": "^2.0"
     },


### PR DESCRIPTION
Added v0.16 to the acceptable `league/openapi-psr7-validator` version constraints to fix an dependency issue with the `psr/cache` package.

```
$ composer require --dev kirschbaum-development/laravel-openapi-validator
Using version ^0.1.2 for kirschbaum-development/laravel-openapi-validator
./composer.json has been updated
Running composer update kirschbaum-development/laravel-openapi-validator
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - league/openapi-psr7-validator[0.14, ..., 0.15.2] require psr/cache ^1.0 -> found psr/cache[1.0.0, 1.0.1] but the package is fixed to 3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - kirschbaum-development/laravel-openapi-validator 0.1.2 requires league/openapi-psr7-validator ^0.14|^0.15 -> satisfiable by league/openapi-psr7-validator[0.14, 0.15, 0.15.1, 0.15.2].
    - Root composer.json requires kirschbaum-development/laravel-openapi-validator ^0.1.2 -> satisfiable by kirschbaum-development/laravel-openapi-validator[0.1.2].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

It doesn't seem like there are any major changes that would cause issues by upgrading to v0.16 of `league/openapi-psr7-validator`.