### PR TITLE
Updated `league/openapi-psr7-validator` version constraints  to also allow v0.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "league/openapi-psr7-validator": "^0.14|^0.15|^0.16",
+        "league/openapi-psr7-validator": "^0.14|^0.15|^0.16|^0.17",
         "nyholm/psr7": "^1.3",
         "symfony/psr-http-message-bridge": "^2.0"
     },


### PR DESCRIPTION
We are using your excellent package for a project, and whole lot of tests are currently failing, because `league/openapi-psr7-validator` needs to be updated to `v0.17`.

I have updated the dependency, and ran the PHPUnit tests, that are all still green, using v0.17.