### PR TITLE
Fix spoof authentication

### DIFF
--- a/src/ValidatesOpenApiSpec.php
+++ b/src/ValidatesOpenApiSpec.php
@@ -226,11 +226,11 @@ trait ValidatesOpenApiSpec
      */
     protected function getAuthenticatedRequest(SymfonyRequest $request): SymfonyRequest
     {
-        // Spoofing when authentication headers are not present.
         if ($request->headers->has('Authorization')) {
             return $request;
         }
 
+        // Spoofing when authentication headers are not present.
         $authenticatedRequest = clone $request;
         $authenticatedRequest->headers->set('Authorization', 'Bearer token');
         

--- a/src/ValidatesOpenApiSpec.php
+++ b/src/ValidatesOpenApiSpec.php
@@ -229,11 +229,12 @@ trait ValidatesOpenApiSpec
         // Spoofing when authentication headers are not present.
         if ($request->headers->has('Authorization')) {
             return $request;
-        } else {
-            $authenticatedRequest = clone $request;
-            $authenticatedRequest->headers->set('Authorization', 'Bearer token');
-            return $authenticatedRequest;
         }
+
+        $authenticatedRequest = clone $request;
+        $authenticatedRequest->headers->set('Authorization', 'Bearer token');
+        
+        return $authenticatedRequest;
     }
 
     /**

--- a/src/ValidatesOpenApiSpec.php
+++ b/src/ValidatesOpenApiSpec.php
@@ -226,10 +226,14 @@ trait ValidatesOpenApiSpec
      */
     protected function getAuthenticatedRequest(SymfonyRequest $request): SymfonyRequest
     {
-        $authenticatedRequest = clone $request;
-        $authenticatedRequest->headers->set('Authorization', 'Bearer token');
-
-        return $authenticatedRequest;
+        // Spoofing when authentication headers are not present.
+        if ($request->headers->has('Authorization')) {
+            return $request;
+        } else {
+            $authenticatedRequest = clone $request;
+            $authenticatedRequest->headers->set('Authorization', 'Bearer token');
+            return $authenticatedRequest;
+        }
     }
 
     /**

--- a/tests/ValidatesRequestsTest.php
+++ b/tests/ValidatesRequestsTest.php
@@ -115,6 +115,15 @@ class ValidatesRequestsTest extends TestCase
             ],
             true,
         ];
+
+        yield 'Authentication required' => [
+            [
+                'method' => 'GET',
+                'uri' => 'private',
+                'server' => ['HTTP_Authorization' => 'Basic MTIzNDU2Nzg5MDo='],
+            ],
+            true,
+        ];
     }
 
     private function makeRequest($method, $uri, $parameters = [], $cookies = [], $files = [], $server = [], $content = null)

--- a/tests/ValidatorBuildAndSetupTest.php
+++ b/tests/ValidatorBuildAndSetupTest.php
@@ -150,7 +150,23 @@ class ValidatorBuildAndSetupTest extends TestCase
      */
     public function testBypassesAuthenticationInRequests()
     {
-        $request = $this->getAuthenticatedRequest(new SymfonyRequest());
+        $originRequest = new SymfonyRequest();
+        $request = $this->getAuthenticatedRequest($originRequest);
         $this->assertTrue($request->headers->has('Authorization'));
+        $this->assertNotSame($originRequest, $request);
+    }
+
+    /**
+     * @test
+     */
+    public function testDontSpoofAuthenticationInRequests()
+    {
+        $originRequest = new SymfonyRequest();
+        $authenticationHeaderValue = 'Basic MTIzNDU2Nzg5MDo=';
+        $originRequest->headers->set('Authorization', $authenticationHeaderValue);
+        $request = $this->getAuthenticatedRequest($originRequest);
+        $this->assertTrue($request->headers->has('Authorization'));
+        $this->assertEquals($authenticationHeaderValue, $request->headers->get('Authorization'));
+        $this->assertSame($originRequest, $request);
     }
 }

--- a/tests/fixtures/OpenAPI.yaml
+++ b/tests/fixtures/OpenAPI.yaml
@@ -72,3 +72,15 @@ paths:
       responses:
         '200':
           description: OK
+  /private:
+    get:
+      responses:
+        '200':
+          description: OK
+      security:
+        - Basic: []
+components:
+  securitySchemes:
+    Basic:
+      type: http
+      scheme: basic


### PR DESCRIPTION
# Problem

When validating a request for an endpoint that requires authentication, the validation fails due to spoofed authentication.

Error example
```log
Validation failed with unexpected exception PHPUnit\Framework\AssertionFailedError
None of security schemas did match for Request [get /private]
```
https://github.com/k2tzumi/laravel-openapi-validator/runs/7262608677?check_suite_focus=true#step:6:20

# Proposal for revision

Avoid spoofed authentication when authentication headers are present
