### PR TITLE
fix ${var} string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1, 8.2]
         laravel: [6.*, 7.*, 8.*, 9.*]
         include:
           - laravel: 9.*
@@ -27,7 +27,10 @@ jobs:
             laravel: 7.*
           - php: 8.1
             laravel: 6.*
-
+          - php: 8.2
+            laravel: 7.*
+          - php: 8.2
+            laravel: 6.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/src/ValidatesOpenApiSpec.php
+++ b/src/ValidatesOpenApiSpec.php
@@ -45,7 +45,7 @@ trait ValidatesOpenApiSpec
             } elseif ($specType === 'yaml') {
                 $this->openApiValidatorBuilder = (new ValidatorBuilder())->fromYaml($this->getOpenApiSpec());
             } else {
-                throw new UnknownParserForFileTypeException("Unknown parser for file type ${specType}");
+                throw new UnknownParserForFileTypeException("Unknown parser for file type {$specType}");
             }
         }
 
@@ -153,7 +153,7 @@ trait ValidatesOpenApiSpec
         $codes = $this->responseCodesToSkip ?? ['5\d\d'];
 
         return '/' . implode('|', array_map(function ($code) {
-            return "(${code})";
+            return "({$code})";
         }, $codes)) . '/';
     }
 
@@ -213,7 +213,7 @@ trait ValidatesOpenApiSpec
         $type = strtolower(Str::afterLast($this->getOpenApiSpecPath(), '.'));
 
         if (! $type || ! in_array($type, ['json', 'yaml'])) {
-            throw new UnknownSpecFileTypeException("Expected json or yaml type OpenAPI spec, got ${type}");
+            throw new UnknownSpecFileTypeException("Expected json or yaml type OpenAPI spec, got {$type}");
         }
 
         return $type;

--- a/tests/ValidatesReponsesTest.php
+++ b/tests/ValidatesReponsesTest.php
@@ -39,7 +39,7 @@ class ValidatesResponsesTest extends TestCase
             if (is_null($expectedException)) {
                 $this->fail('Validation failed with unexpected exception ' . get_class($exception) . PHP_EOL . $exception->getMessage());
             }
-            $this->assertInstanceOf($expectedException, $exception, "Expected an exception of class [${expectedException}] to be thrown, got " . get_class($exception));
+            $this->assertInstanceOf($expectedException, $exception, "Expected an exception of class [{$expectedException}] to be thrown, got " . get_class($exception));
 
             $this->assertFalse($expectSuccess);
             // End the test here

--- a/tests/ValidatesRequestsTest.php
+++ b/tests/ValidatesRequestsTest.php
@@ -40,7 +40,7 @@ class ValidatesRequestsTest extends TestCase
             if (is_null($expectedException)) {
                 $this->fail('Validation failed with unexpected exception ' . get_class($exception) . PHP_EOL . $exception->getMessage());
             }
-            $this->assertInstanceOf($expectedException, $exception, "Expected an exception of class [${expectedException}] to be thrown, got " . get_class($exception));
+            $this->assertInstanceOf($expectedException, $exception, "Expected an exception of class [{$expectedException}] to be thrown, got " . get_class($exception));
 
             $this->assertFalse($expectSuccess);
             // End the test here

--- a/tests/ValidatorBuildAndSetupTest.php
+++ b/tests/ValidatorBuildAndSetupTest.php
@@ -24,7 +24,7 @@ class ValidatorBuildAndSetupTest extends TestCase
      */
     public function testGetsOpenApiValidatorBuilder(string $extension)
     {
-        $this->app['config']->set('openapi_validator.spec_path', __DIR__."/fixtures/OpenAPI.${extension}");
+        $this->app['config']->set('openapi_validator.spec_path', __DIR__."/fixtures/OpenAPI.{$extension}");
         $builder = $this->getOpenApiValidatorBuilder();
 
         $this->assertInstanceOf(ValidatorBuilder::class, $builder);
@@ -40,13 +40,27 @@ class ValidatorBuildAndSetupTest extends TestCase
 
     /**
      * @test
+     * @dataProvider provideSpecUnknownFormats
      */
-    public function testThrowsExceptionForUnknownFormat()
+    public function testThrowsExceptionForUnknownFormat(string $extension)
     {
-        $this->app['config']->set('openapi_validator.spec_path', __DIR__.'/fixtures/OpenAPI.banana');
+        $this->app['config']->set('openapi_validator.spec_path', __DIR__ . "/fixtures/OpenAPI.{$extension}");
 
         $this->expectException(UnknownSpecFileTypeException::class);
+        $this->expectErrorMessage("Expected json or yaml type OpenAPI spec, got {$extension}");
         $this->getSpecFileType();
+    }
+
+    /**
+     * @return array
+     */
+    public function provideSpecUnknownFormats(): array
+    {
+        return [
+            ['banana'],
+            ['jsonn'],
+            ['yamll'],
+        ];
     }
 
     /**
@@ -105,7 +119,7 @@ class ValidatorBuildAndSetupTest extends TestCase
     public function provideResponseCodes()
     {
         for ($i = 0; $i <= 8; $i++) {
-            yield "Skips 50${i} by default" => [500 + $i, [], true];
+            yield "Skips 50{$i} by default" => [500 + $i, [], true];
         }
 
         yield 'Skips other 500s by default (1)' => [


### PR DESCRIPTION
# proposal

From PHP8.2,  `${var}`  will be depreciated.
To avoid the deprecation notice, I have replaced some variables to have the curly braces cover the dollar sign.

# FYI
- https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated
- https://www.php.net/manual/en/migration82.deprecated.php
