### PR TITLE
Bump thephpleague/openapi-psr7-validator package version to 0.22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "league/openapi-psr7-validator": "^0.14|^0.15|^0.16|^0.17|^0.18|^0.19|^0.20|^0.21",
+        "league/openapi-psr7-validator": "^0.14|^0.15|^0.16|^0.17|^0.18|^0.19|^0.20|^0.21|^0.22",
         "nyholm/psr7": "^1.3",
         "symfony/psr-http-message-bridge": "^2.0"
     },


### PR DESCRIPTION
Bump thephpleague/openapi-psr7-validator package version to newly updated 0.22

https://github.com/thephpleague/openapi-psr7-validator/releases/tag/0.22

Mostly due to changes
> Updated dependencies: psr/http-message 2.x & league/uri 7.x