### PR TITLE
Laravel 12.* upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-pw-v2-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: run-tests
 
 on:
   - push
-
+  - pull_request
+    
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -11,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.0, 8.1, 8.2]
-        laravel: ['9.*', '10.*', '11.*']
+        laravel: ['9.*', '10.*', '11.*', '12.*']
         include:
           - laravel: 11.*
             testbench: 9.*
@@ -19,12 +20,18 @@ jobs:
             testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 12.*
+            testbench: 10.*
         exclude:
           - php: 8.0
             laravel: 10.*
           - laravel: 11.*
             php: 8.0
           - laravel: 11.*
+            php: 8.1
+          - laravel: 12.*
+            php: 8.0
+          - laravel: 12.*
             php: 8.1
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
         "league/openapi-psr7-validator": "^0.14|^0.15|^0.16|^0.17|^0.18|^0.19|^0.20|^0.21|^0.22",
         "nyholm/psr7": "^1.3",
         "symfony/psr-http-message-bridge": "^2.0|^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "7.*|^8.0|^9.0",
+        "orchestra/testbench": "7.*|^8.0|^9.0|^10.0",
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^9.0|^10.5",
+        "phpunit/phpunit": "^9.0|^10.5|^11.5.3",
         "fakerphp/faker": "^1.9.1"
     },
     "autoload": {


### PR DESCRIPTION
This closes https://github.com/kirschbaum-development/laravel-openapi-validator/issues/22 

Adds the following:
- This ensures CI tests run on PR requests ( wont here as it's not merged yet :) )
- Updates the CI actions - as they were using v1 items
- Applies the [Laravel shift pr changes](https://github.com/kirschbaum-development/laravel-openapi-validator/pull/21) 


[See the tests here](https://github.com/jackbayliss/laravel-openapi-validator/actions/runs/14134242713)

In the meantime i'm going to try this manually in a 12 project, so hold with me